### PR TITLE
moodID updated + image deletion from DB

### DIFF
--- a/moodBookProject/app/app.iml
+++ b/moodBookProject/app/app.iml
@@ -20,7 +20,7 @@
         <option name="MANIFEST_FILE_RELATIVE_PATH" value="/src/main/AndroidManifest.xml" />
         <option name="RES_FOLDER_RELATIVE_PATH" value="/src/main/res" />
         <option name="RES_FOLDERS_RELATIVE_PATH" value="file://$MODULE_DIR$/src/main/res;file://$MODULE_DIR$/src/debug/res;file://$MODULE_DIR$/build/generated/res/google-services/debug;file://$MODULE_DIR$/build/generated/res/resValues/debug" />
-        <option name="TEST_RES_FOLDERS_RELATIVE_PATH" value="file://$MODULE_DIR$/build/generated/res/resValues/androidTest/debug" />
+        <option name="TEST_RES_FOLDERS_RELATIVE_PATH" value="" />
         <option name="ASSETS_FOLDER_RELATIVE_PATH" value="/src/main/assets" />
       </configuration>
     </facet>

--- a/moodBookProject/app/src/main/java/com/example/moodbook/DBMoodSetter.java
+++ b/moodBookProject/app/src/main/java/com/example/moodbook/DBMoodSetter.java
@@ -132,7 +132,7 @@ public class DBMoodSetter {
                         if (documentSnapshot != null) {
                             // get mood docId from moodCount
                             Double m = documentSnapshot.getDouble("mood_Count");
-                            String moodID = String.valueOf(m);
+                            String moodID = String.valueOf(m) + MainActivity.getUsername(); //increment int + username as a moodID
                             addImg(moodID, mood);
                             // add new mood into db
                             addMoodAfterDocId(moodID, mood);

--- a/moodBookProject/app/src/main/java/com/example/moodbook/DBMoodSetter.java
+++ b/moodBookProject/app/src/main/java/com/example/moodbook/DBMoodSetter.java
@@ -255,6 +255,8 @@ public class DBMoodSetter {
                         @Override
                         public void onSuccess(Void aVoid) {
                             showStatusMessage("Deleted successfully: " + moodID);
+                            removeImgFromDB(moodID);
+
                         }
                     })
                     .addOnFailureListener(new OnFailureListener() {
@@ -264,6 +266,30 @@ public class DBMoodSetter {
                         }
                     });
         }
+
+
+        /**
+         *
+         * @param moodID
+         */
+
+        public void removeImgFromDB(final String moodID) {
+            StorageReference photoRef = photoReference.child(moodID);
+            photoRef.delete().addOnSuccessListener(new OnSuccessListener<Void>() {
+                @Override
+                public void onSuccess(Void aVoid) {
+                    // File deleted successfully
+                    Log.d(TAG, "Mood image deleted successfully.");
+                }
+            }).addOnFailureListener(new OnFailureListener() {
+                @Override
+                public void onFailure(@NonNull Exception exception) {
+                    // Uh-oh, an error occurred!
+                    Log.d(TAG, "Failed to delete mood image.");
+                }
+            });
+        }
+
 
         /**
          * This edits  a specific mood in the database given the mood's docID and the parameters to edit

--- a/moodBookProject/app/src/main/java/com/example/moodbook/MainActivity.java
+++ b/moodBookProject/app/src/main/java/com/example/moodbook/MainActivity.java
@@ -51,7 +51,7 @@ public class MainActivity extends AppCompatActivity   {
     private ActionBarDrawerToggle actionBarDrawerToggle;
     private Toolbar toolbar;
     private FirebaseFirestore db;
-    private String name;
+    private static String name;
     private String email;
 
 
@@ -184,6 +184,10 @@ public class MainActivity extends AppCompatActivity   {
         mAuth.getInstance().signOut();
         startActivity(new Intent(this, LoginActivity.class));
         finish();
+    }
+
+    public static String getUsername(){
+        return name;
     }
 
 }


### PR DESCRIPTION
- Fixed having the same id being used for two concurrently created moods. 
- Also deletes the image file from storage when a mood is deleted.